### PR TITLE
Show a warning about missing `jq` when triggered by a pull request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,11 @@ runs:
         esac
         echo "$folder" >> $GITHUB_PATH
       shell: bash
+    - if: ${{ github.event_name == 'pull_request' }}
+      run: command -V jq || echo "::warning::$WARNING"
+      shell: bash
+      env:
+        WARNING: 'To be able to properly obtain the originating PR-number, Testspace requires the jq utility to be installed on your OS image (named jq/jq.exe and on the system PATH)'
     - run: |
         testspace --version
         domain=${{ inputs.domain }}


### PR DESCRIPTION
Otherwise, there is no explanation what went wrong, and no error/warning message from `testspace` about `jq` at all