### PR TITLE
switch CI to run on macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Testspace client install & config


### PR DESCRIPTION
GH does not provide `macos-12` hosted runner anymore. Switch to using `macos-13`